### PR TITLE
Change SetJSON to correctly handle pointer args

### DIFF
--- a/json.go
+++ b/json.go
@@ -25,8 +25,17 @@ func (c *Command) SetJSON(value interface{}) *SetRawCommand {
 		Value: by,
 	}
 
-	refType := reflect.TypeOf(value)
 	refValue := reflect.ValueOf(value)
+	// Handling case with the pointer as an argument
+	if refValue.Kind() == reflect.Ptr {
+		refValue = refValue.Elem()
+	}
+
+	refType := reflect.TypeOf(value)
+	// Avoiding panic when zero value passed
+	if refValue.IsValid() {
+		refType = refValue.Type()
+	}
 
 	// Indexes from struct value
 	if refType.Kind() == reflect.Struct {


### PR DESCRIPTION
This fixes an issue with not grabbed `goriakindex` tags when we pass the pointer to SetJSON method.

Before this commit the behavior was:
- call SetJSON with the pointer to a struct which has `goriakindex` tag.
- under the hood, the method determinates kind of passed value as `ptr` and doesn't try to find the field with tag.
- data are silently written into a bucket, without a secondary key.

In this commit added an extra check on pointer and data passed by pointer handled in the same way as data passed by value.
Test case included into the commit.