### PR TITLE
Removed unused field

### DIFF
--- a/query_get_value.go
+++ b/query_get_value.go
@@ -22,9 +22,6 @@ type GetRawCommand struct {
 
 	isRawOutput bool
 
-	// VClock is used in conflict resolution
-	// http://docs.basho.com/riak/kv/2.1.4/developing/usage/conflict-resolution/
-	vclock               []byte
 	conflictResolverFunc func([]ConflictObject) ResolvedConflict
 }
 


### PR DESCRIPTION
`vclock` is private and not used anywhere in the package.